### PR TITLE
Add setting to overshoot "Date and Time" by one, then DUP to recover.

### DIFF
--- a/MainWindow.Designer.cs
+++ b/MainWindow.Designer.cs
@@ -31,6 +31,8 @@
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainWindow));
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
+            this.ButtonAdvanceDate = new System.Windows.Forms.Button();
+            this.CheckEnableFilters = new System.Windows.Forms.CheckBox();
             this.ButtonDisconnect = new System.Windows.Forms.Button();
             this.ButtonConnect = new System.Windows.Forms.Button();
             this.ConnectionStatusText = new System.Windows.Forms.Label();
@@ -53,7 +55,6 @@
             this.IVs = new System.Windows.Forms.TextBox();
             this.LabelIVs = new System.Windows.Forms.Label();
             this.ButtonReadRaids = new System.Windows.Forms.Button();
-            this.ButtonAdvanceDate = new System.Windows.Forms.Button();
             this.IsEvent = new System.Windows.Forms.CheckBox();
             this.LabelIsEvent = new System.Windows.Forms.Label();
             this.Difficulty = new System.Windows.Forms.TextBox();
@@ -86,12 +87,40 @@
             this.Rewards = new System.Windows.Forms.Button();
             this.LabelSandwichBonus = new System.Windows.Forms.Label();
             this.RaidBoost = new System.Windows.Forms.ComboBox();
-            this.CheckEnableFilters = new System.Windows.Forms.CheckBox();
             this.ComboIndex = new System.Windows.Forms.ComboBox();
             this.SendScreenshot = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.Sprite)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.GemIcon)).BeginInit();
             this.SuspendLayout();
+            // 
+            // ButtonAdvanceDate
+            // 
+            this.ButtonAdvanceDate.Enabled = false;
+            this.ButtonAdvanceDate.Location = new System.Drawing.Point(117, 110);
+            this.ButtonAdvanceDate.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.ButtonAdvanceDate.Name = "ButtonAdvanceDate";
+            this.ButtonAdvanceDate.Size = new System.Drawing.Size(97, 27);
+            this.ButtonAdvanceDate.TabIndex = 81;
+            this.ButtonAdvanceDate.Text = "Advance Date";
+            this.toolTip.SetToolTip(this.ButtonAdvanceDate, "Advance Date performs one (1) time set.\r\n\r\nIf Stop Filters are defined, Advance D" +
+        "ate\r\ncontinues advancing the date until a stop\r\nfilter has been hit.");
+            this.ButtonAdvanceDate.UseVisualStyleBackColor = true;
+            this.ButtonAdvanceDate.Click += new System.EventHandler(this.ButtonAdvanceDate_Click);
+            // 
+            // CheckEnableFilters
+            // 
+            this.CheckEnableFilters.AutoSize = true;
+            this.CheckEnableFilters.Checked = true;
+            this.CheckEnableFilters.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.CheckEnableFilters.Location = new System.Drawing.Point(119, 254);
+            this.CheckEnableFilters.Name = "CheckEnableFilters";
+            this.CheckEnableFilters.Size = new System.Drawing.Size(95, 19);
+            this.CheckEnableFilters.TabIndex = 119;
+            this.CheckEnableFilters.Text = "Enable Filters";
+            this.toolTip.SetToolTip(this.CheckEnableFilters, "Enable Filters enables or disables all filters\r\nentirely.\r\n\r\nEnabled - Advance Da" +
+        "te will continue until\r\na match occurs from a filter.\r\n\r\nDisabled - Advance Date" +
+        " will only advance\r\none (1) day.");
+            this.CheckEnableFilters.UseVisualStyleBackColor = true;
             // 
             // ButtonDisconnect
             // 
@@ -316,20 +345,6 @@
             this.ButtonReadRaids.UseVisualStyleBackColor = true;
             this.ButtonReadRaids.Click += new System.EventHandler(this.ButtonReadRaids_Click);
             // 
-            // ButtonAdvanceDate
-            // 
-            this.ButtonAdvanceDate.Enabled = false;
-            this.ButtonAdvanceDate.Location = new System.Drawing.Point(117, 110);
-            this.ButtonAdvanceDate.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.ButtonAdvanceDate.Name = "ButtonAdvanceDate";
-            this.ButtonAdvanceDate.Size = new System.Drawing.Size(97, 27);
-            this.ButtonAdvanceDate.TabIndex = 81;
-            this.ButtonAdvanceDate.Text = "Advance Date";
-            this.toolTip.SetToolTip(this.ButtonAdvanceDate, "Advance Date performs one (1) time set.\r\n\r\nIf Stop Filters are defined, Advance D" +
-        "ate\r\ncontinues advancing the date until a stop\r\nfilter has been hit.");
-            this.ButtonAdvanceDate.UseVisualStyleBackColor = true;
-            this.ButtonAdvanceDate.Click += new System.EventHandler(this.ButtonAdvanceDate_Click);
-            // 
             // IsEvent
             // 
             this.IsEvent.AutoCheck = false;
@@ -356,7 +371,7 @@
             this.Difficulty.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.Difficulty.Name = "Difficulty";
             this.Difficulty.ReadOnly = true;
-            this.Difficulty.Size = new System.Drawing.Size(88, 22);
+            this.Difficulty.Size = new System.Drawing.Size(80, 22);
             this.Difficulty.TabIndex = 86;
             // 
             // LabelDifficulty
@@ -661,21 +676,6 @@
             this.RaidBoost.TabIndex = 117;
             this.RaidBoost.Text = "w";
             this.RaidBoost.SelectedIndexChanged += new System.EventHandler(this.RaidBoost_SelectedIndexChanged);
-            // 
-            // CheckEnableFilters
-            // 
-            this.CheckEnableFilters.AutoSize = true;
-            this.CheckEnableFilters.Checked = true;
-            this.CheckEnableFilters.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.CheckEnableFilters.Location = new System.Drawing.Point(119, 254);
-            this.CheckEnableFilters.Name = "CheckEnableFilters";
-            this.CheckEnableFilters.Size = new System.Drawing.Size(95, 19);
-            this.CheckEnableFilters.TabIndex = 119;
-            this.CheckEnableFilters.Text = "Enable Filters";
-            this.toolTip.SetToolTip(this.CheckEnableFilters, "Enable Filters enables or disables all filters\r\nentirely.\r\n\r\nEnabled - Advance Da" +
-        "te will continue until\r\na match occurs from a filter.\r\n\r\nDisabled - Advance Date" +
-        " will only advance\r\none (1) day.");
-            this.CheckEnableFilters.UseVisualStyleBackColor = true;
             // 
             // ComboIndex
             // 

--- a/MainWindow.cs
+++ b/MainWindow.cs
@@ -540,10 +540,9 @@ namespace RaidCrawler
 
             // Navigate to "Date and Time"
             await Click(DRIGHT, 0_200 + BaseDelay, token).ConfigureAwait(false);
-            // I tried using holds here but could not get the timing consistent
-            // Even if this is slightly slower, it is at least consistent
-            // And not missing any cycles means it's faster overall
-            for (int i = 0; i < Settings.Default.CfgSystemDDownPresses; i++) await Click(DDOWN, 0_050 + BaseDelay, token).ConfigureAwait(false);
+            // Hold down to overshoot Date/Time by one. DUP to recover.
+            await PressAndHold(DDOWN, (int)Settings.Default.CfgSystemOvershoot, 0, token).ConfigureAwait(false);
+            await Click(DUP, 0_500, token).ConfigureAwait(false);
             await Click(A, (int)Settings.Default.CfgSubmenu + BaseDelay, token).ConfigureAwait(false);
 
             // Navigate to Change Date/Time

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -278,7 +278,22 @@ namespace RaidCrawler.Properties {
                 this["CfgUseTouch"] = value;
             }
         }
-        
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool CfgUseOvershoot
+        {
+            get
+            {
+                return ((bool)(this["CfgUseOvershoot"]));
+            }
+            set
+            {
+                this["CfgUseOvershoot"] = value;
+            }
+        }
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("0, 0")]

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -143,7 +143,22 @@ namespace RaidCrawler.Properties {
                 this["CfgSystemDDownPresses"] = value;
             }
         }
-        
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("950")]
+        public decimal CfgSystemOvershoot
+        {
+            get
+            {
+                return ((decimal)(this["CfgSystemOvershoot"]));
+            }
+            set
+            {
+                this["CfgSystemOvershoot"] = value;
+            }
+        }
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("1800")]

--- a/Structures/FlatbufferDumper.cs
+++ b/Structures/FlatbufferDumper.cs
@@ -1,7 +1,5 @@
 ﻿using FlatSharp;
-using System.Buffers.Binary;
 using System.Diagnostics;
-using System.IO;
 
 namespace RaidCrawler.Structures
 {
@@ -66,7 +64,7 @@ namespace RaidCrawler.Structures
             var pickle = ms.ToArray();
             var extra_moves = ms2.ToArray();
             var rewards = ms3.ToArray();
-            return new[] {pickle, extra_moves, rewards};
+            return new[] { pickle, extra_moves, rewards };
         }
 
         public static byte[][] DumpDistributionRaids(byte[] encounters)
@@ -118,7 +116,7 @@ namespace RaidCrawler.Structures
                 var prios = FlatBufferSerializer.Default.Parse<DeliveryRaidPriorityArray>(flatbuffer);
                 return (prios.Table[0].DeliveryGroupID, prios.Table[0].VersionNo);
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 Debug.WriteLine(ex.ToString());
                 return (new DeliveryRaidPriorityArray().Table[0].DeliveryGroupID, 0);

--- a/Structures/NotificationHandler.cs
+++ b/Structures/NotificationHandler.cs
@@ -11,7 +11,8 @@ namespace RaidCrawler.Structures
         private static HttpClient? _client;
         public static HttpClient Client
         {
-            get {
+            get 
+            {
                 if (_client == null)
                     _client = new HttpClient();
                 return _client;

--- a/Structures/Offsets.cs
+++ b/Structures/Offsets.cs
@@ -10,7 +10,7 @@ namespace RaidCrawler.Structures
 
         public const string RaidBlockPointer = "[[main+4384B18]+180]+40";
         public const string SaveBlockPointer = "[[[main+4385F30]+80]+8]"; // Thanks Lincoln-LM!
-        public static (int, uint)[] DifficultyFlags = { ( 0x2BF20, 0xEC95D8EF ), (0x1F400, 0xA9428DFE), (0x1B640, 0x9535F471), (0x13EC0, 0x6E7F8220) }; // Thanks Lincoln-LM!
+        public static (int, uint)[] DifficultyFlags = { (0x2BF20, 0xEC95D8EF), (0x1F400, 0xA9428DFE), (0x1B640, 0x9535F471), (0x13EC0, 0x6E7F8220) }; // Thanks Lincoln-LM!
         public static (int, uint) BCATRaidBinaryLocation = (0x1040, 0x520A1B0); // Thanks Lincoln-LM!
         public static (int, uint) BCATRaidPriorityLocation = (0x1860, 0x95451E4); // Thanks Lincoln-LM!
         public static (int, uint) BCATRaidFixedRewardLocation = (0x16D40, 0x7D6C2B82);

--- a/Structures/RaidFilter.cs
+++ b/Structures/RaidFilter.cs
@@ -45,10 +45,10 @@ namespace RaidCrawler.Structures
             return StarsComp switch
             {
                 0 => enc.Stars == (int)Stars,
-                1 => enc.Stars >  (int)Stars,
+                1 => enc.Stars > (int)Stars,
                 2 => enc.Stars >= (int)Stars,
                 3 => enc.Stars <= (int)Stars,
-                4 => enc.Stars <  (int)Stars,
+                4 => enc.Stars < (int)Stars,
                 _ => false
             };
         }
@@ -61,12 +61,13 @@ namespace RaidCrawler.Structures
             if (rewards == null)
                 return false;
             var count = rewards.Where(z => RewardItems.Contains(z.Item1)).Count();
-            return RewardsComp switch {
+            return RewardsComp switch 
+            {
                 0 => count == RewardsCount,
-                1 => count >  RewardsCount,
+                1 => count > RewardsCount,
                 2 => count >= RewardsCount,
                 3 => count <= RewardsCount,
-                4 => count <  RewardsCount,
+                4 => count < RewardsCount,
                 _ => false
             };
         }
@@ -159,7 +160,7 @@ namespace RaidCrawler.Structures
 
         public bool IsBatchFilterSatisfied(ITeraRaid? encounter, Raid raid)
         {
-            if (BatchFilters == null) 
+            if (BatchFilters == null)
                 return true;
             if (encounter == null)
                 return false;
@@ -178,7 +179,7 @@ namespace RaidCrawler.Structures
         public bool FilterSatisfied(ITeraRaid? encounter, Raid raid, int SandwichBoost)
         {
             return Enabled && IsIVsSatisfied(encounter, raid) && IsShinySatisfied(raid) && IsSpeciesSatisfied(encounter)
-                && IsNatureSatisfied(encounter, raid) && IsStarsSatisfied(encounter) && IsTeraTypeSatisfied(raid) 
+                && IsNatureSatisfied(encounter, raid) && IsStarsSatisfied(encounter) && IsTeraTypeSatisfied(raid)
                 && IsRewardsSatisfied(encounter, raid, SandwichBoost) && IsGenderSatisfied(encounter, raid) && IsBatchFilterSatisfied(encounter, raid);
         }
 

--- a/Structures/RaidRewards.cs
+++ b/Structures/RaidRewards.cs
@@ -116,7 +116,7 @@ namespace RaidCrawler.Structures
                 Species.Houndour or Species.Houndoom => 1990,
                 Species.Phanpy or Species.Donphan => 1991,
                 Species.Stantler or Species.Wyrdeer => 1992,
-                Species.Larvitar or Species.Pupitar or Species.Tyranitar => 1994,
+                Species.Larvitar or Species.Pupitar or Species.Tyranitar => 1993,
                 Species.Wingull or Species.Pelipper => 1994,
                 Species.Ralts or Species.Kirlia or Species.Gardevoir or Species.Gallade => 1995,
                 Species.Surskit or Species.Masquerain => 1996,

--- a/Structures/TeraDistribution.cs
+++ b/Structures/TeraDistribution.cs
@@ -1,8 +1,6 @@
 ﻿using PKHeX.Core;
 using System.Diagnostics;
-using FlatSharp;
 using static System.Buffers.Binary.BinaryPrimitives;
-using System.IO;
 
 namespace RaidCrawler.Structures
 {
@@ -129,9 +127,9 @@ namespace RaidCrawler.Structures
 
         public static int GetDeliveryGroupID(int eventct, DeliveryGroupID ids)
         {
-            int[] cts = new int[10] { ids.GroupID01, ids.GroupID02, ids.GroupID03, ids.GroupID04, ids.GroupID05, 
+            int[] cts = new int[10] { ids.GroupID01, ids.GroupID02, ids.GroupID03, ids.GroupID04, ids.GroupID05,
                                       ids.GroupID06, ids.GroupID07, ids.GroupID08, ids.GroupID09, ids.GroupID10 };
-            for (int i=0; i < cts.Length; i++)
+            for (int i = 0; i < cts.Length; i++)
             {
                 var ct = cts[i];
                 if (eventct < ct)

--- a/Subforms/ConfigWindow.Designer.cs
+++ b/Subforms/ConfigWindow.Designer.cs
@@ -61,6 +61,8 @@
             this.UseTouch = new System.Windows.Forms.CheckBox();
             this.DiscordWebhook = new System.Windows.Forms.TextBox();
             this.EnableDiscordNotifications = new System.Windows.Forms.CheckBox();
+            this.label13 = new System.Windows.Forms.Label();
+            this.SystemOvershoot = new System.Windows.Forms.NumericUpDown();
             ((System.ComponentModel.ISupportInitialize)(this.BaseDelay)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.SystemDDownPresses)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NavigateToSettings)).BeginInit();
@@ -72,6 +74,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.ReturnHome)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.ReturnGame)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.DaysToSkip)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.SystemOvershoot)).BeginInit();
             this.SuspendLayout();
             // 
             // FocusWindow
@@ -181,7 +184,7 @@
             // 
             // Save
             // 
-            this.Save.Location = new System.Drawing.Point(12, 548);
+            this.Save.Location = new System.Drawing.Point(12, 576);
             this.Save.Name = "Save";
             this.Save.Size = new System.Drawing.Size(327, 23);
             this.Save.TabIndex = 12;
@@ -296,7 +299,7 @@
             // label7
             // 
             this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(12, 405);
+            this.label7.Location = new System.Drawing.Point(12, 433);
             this.label7.Name = "label7";
             this.label7.Size = new System.Drawing.Size(123, 15);
             this.label7.TabIndex = 25;
@@ -304,7 +307,7 @@
             // 
             // Submenu
             // 
-            this.Submenu.Location = new System.Drawing.Point(271, 403);
+            this.Submenu.Location = new System.Drawing.Point(271, 431);
             this.Submenu.Maximum = new decimal(new int[] {
             9999,
             0,
@@ -322,7 +325,7 @@
             // label8
             // 
             this.label8.AutoSize = true;
-            this.label8.Location = new System.Drawing.Point(12, 434);
+            this.label8.Location = new System.Drawing.Point(12, 462);
             this.label8.Name = "label8";
             this.label8.Size = new System.Drawing.Size(138, 15);
             this.label8.TabIndex = 27;
@@ -330,7 +333,7 @@
             // 
             // DateChange
             // 
-            this.DateChange.Location = new System.Drawing.Point(271, 432);
+            this.DateChange.Location = new System.Drawing.Point(271, 460);
             this.DateChange.Maximum = new decimal(new int[] {
             9999,
             0,
@@ -348,7 +351,7 @@
             // label9
             // 
             this.label9.AutoSize = true;
-            this.label9.Location = new System.Drawing.Point(12, 492);
+            this.label9.Location = new System.Drawing.Point(12, 520);
             this.label9.Name = "label9";
             this.label9.Size = new System.Drawing.Size(160, 15);
             this.label9.TabIndex = 29;
@@ -356,7 +359,7 @@
             // 
             // ReturnHome
             // 
-            this.ReturnHome.Location = new System.Drawing.Point(271, 490);
+            this.ReturnHome.Location = new System.Drawing.Point(271, 518);
             this.ReturnHome.Maximum = new decimal(new int[] {
             9999,
             0,
@@ -374,7 +377,7 @@
             // label10
             // 
             this.label10.AutoSize = true;
-            this.label10.Location = new System.Drawing.Point(12, 521);
+            this.label10.Location = new System.Drawing.Point(12, 549);
             this.label10.Name = "label10";
             this.label10.Size = new System.Drawing.Size(119, 15);
             this.label10.TabIndex = 31;
@@ -382,7 +385,7 @@
             // 
             // ReturnGame
             // 
-            this.ReturnGame.Location = new System.Drawing.Point(271, 519);
+            this.ReturnGame.Location = new System.Drawing.Point(271, 547);
             this.ReturnGame.Maximum = new decimal(new int[] {
             9999,
             0,
@@ -400,7 +403,7 @@
             // label11
             // 
             this.label11.AutoSize = true;
-            this.label11.Location = new System.Drawing.Point(12, 463);
+            this.label11.Location = new System.Drawing.Point(12, 491);
             this.label11.Name = "label11";
             this.label11.Size = new System.Drawing.Size(179, 15);
             this.label11.TabIndex = 33;
@@ -408,7 +411,7 @@
             // 
             // DaysToSkip
             // 
-            this.DaysToSkip.Location = new System.Drawing.Point(271, 461);
+            this.DaysToSkip.Location = new System.Drawing.Point(271, 489);
             this.DaysToSkip.Maximum = new decimal(new int[] {
             99,
             0,
@@ -454,11 +457,39 @@
             this.EnableDiscordNotifications.UseVisualStyleBackColor = true;
             this.EnableDiscordNotifications.CheckedChanged += new System.EventHandler(this.EnableDiscordNotifications_CheckedChanged);
             // 
+            // label13
+            // 
+            this.label13.AutoSize = true;
+            this.label13.Location = new System.Drawing.Point(12, 404);
+            this.label13.Name = "label13";
+            this.label13.Size = new System.Drawing.Size(233, 15);
+            this.label13.TabIndex = 39;
+            this.label13.Text = "Time to hold to overshoot \"Date and Time\"";
+            // 
+            // SystemOvershoot
+            // 
+            this.SystemOvershoot.Location = new System.Drawing.Point(271, 402);
+            this.SystemOvershoot.Maximum = new decimal(new int[] {
+            1200,
+            0,
+            0,
+            0});
+            this.SystemOvershoot.Name = "SystemOvershoot";
+            this.SystemOvershoot.Size = new System.Drawing.Size(68, 23);
+            this.SystemOvershoot.TabIndex = 40;
+            this.SystemOvershoot.Value = new decimal(new int[] {
+            950,
+            0,
+            0,
+            0});
+            // 
             // ConfigWindow
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(351, 582);
+            this.ClientSize = new System.Drawing.Size(351, 621);
+            this.Controls.Add(this.SystemOvershoot);
+            this.Controls.Add(this.label13);
             this.Controls.Add(this.EnableDiscordNotifications);
             this.Controls.Add(this.DiscordWebhook);
             this.Controls.Add(this.UseTouch);
@@ -508,6 +539,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.ReturnHome)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.ReturnGame)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.DaysToSkip)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.SystemOvershoot)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -548,5 +580,7 @@
         private CheckBox UseTouch;
         private TextBox DiscordWebhook;
         private CheckBox EnableDiscordNotifications;
+        private Label label13;
+        private NumericUpDown SystemOvershoot;
     }
 }

--- a/Subforms/ConfigWindow.Designer.cs
+++ b/Subforms/ConfigWindow.Designer.cs
@@ -63,6 +63,8 @@
             this.EnableDiscordNotifications = new System.Windows.Forms.CheckBox();
             this.label13 = new System.Windows.Forms.Label();
             this.SystemOvershoot = new System.Windows.Forms.NumericUpDown();
+            this.UseOvershoot = new System.Windows.Forms.CheckBox();
+            this.label14 = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.BaseDelay)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.SystemDDownPresses)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NavigateToSettings)).BeginInit();
@@ -138,7 +140,7 @@
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(12, 231);
+            this.label1.Location = new System.Drawing.Point(12, 249);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(196, 15);
             this.label1.TabIndex = 8;
@@ -146,7 +148,7 @@
             // 
             // BaseDelay
             // 
-            this.BaseDelay.Location = new System.Drawing.Point(271, 229);
+            this.BaseDelay.Location = new System.Drawing.Point(271, 247);
             this.BaseDelay.Maximum = new decimal(new int[] {
             9999,
             0,
@@ -158,7 +160,7 @@
             // 
             // SystemDDownPresses
             // 
-            this.SystemDDownPresses.Location = new System.Drawing.Point(271, 374);
+            this.SystemDDownPresses.Location = new System.Drawing.Point(271, 392);
             this.SystemDDownPresses.Maximum = new decimal(new int[] {
             99,
             0,
@@ -176,7 +178,7 @@
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(12, 376);
+            this.label3.Location = new System.Drawing.Point(12, 394);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(228, 15);
             this.label3.TabIndex = 11;
@@ -184,7 +186,7 @@
             // 
             // Save
             // 
-            this.Save.Location = new System.Drawing.Point(12, 576);
+            this.Save.Location = new System.Drawing.Point(12, 594);
             this.Save.Name = "Save";
             this.Save.Size = new System.Drawing.Size(327, 23);
             this.Save.TabIndex = 12;
@@ -194,7 +196,7 @@
             // 
             // NavigateToSettings
             // 
-            this.NavigateToSettings.Location = new System.Drawing.Point(271, 287);
+            this.NavigateToSettings.Location = new System.Drawing.Point(271, 305);
             this.NavigateToSettings.Maximum = new decimal(new int[] {
             9999,
             0,
@@ -211,7 +213,7 @@
             // 
             // OpenSettings
             // 
-            this.OpenSettings.Location = new System.Drawing.Point(271, 316);
+            this.OpenSettings.Location = new System.Drawing.Point(271, 334);
             this.OpenSettings.Maximum = new decimal(new int[] {
             9999,
             0,
@@ -228,7 +230,7 @@
             // 
             // OpenHome
             // 
-            this.OpenHome.Location = new System.Drawing.Point(271, 258);
+            this.OpenHome.Location = new System.Drawing.Point(271, 276);
             this.OpenHome.Maximum = new decimal(new int[] {
             9999,
             0,
@@ -246,7 +248,7 @@
             // LabelDelayOpenHOME
             // 
             this.LabelDelayOpenHOME.AutoSize = true;
-            this.LabelDelayOpenHOME.Location = new System.Drawing.Point(12, 260);
+            this.LabelDelayOpenHOME.Location = new System.Drawing.Point(12, 278);
             this.LabelDelayOpenHOME.Name = "LabelDelayOpenHOME";
             this.LabelDelayOpenHOME.Size = new System.Drawing.Size(140, 15);
             this.LabelDelayOpenHOME.TabIndex = 19;
@@ -255,7 +257,7 @@
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(12, 289);
+            this.label4.Location = new System.Drawing.Point(12, 307);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(146, 15);
             this.label4.TabIndex = 20;
@@ -264,7 +266,7 @@
             // label5
             // 
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(12, 318);
+            this.label5.Location = new System.Drawing.Point(12, 336);
             this.label5.Name = "label5";
             this.label5.Size = new System.Drawing.Size(114, 15);
             this.label5.TabIndex = 21;
@@ -273,7 +275,7 @@
             // label6
             // 
             this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(12, 347);
+            this.label6.Location = new System.Drawing.Point(12, 365);
             this.label6.Name = "label6";
             this.label6.Size = new System.Drawing.Size(187, 15);
             this.label6.TabIndex = 23;
@@ -281,7 +283,7 @@
             // 
             // Hold
             // 
-            this.Hold.Location = new System.Drawing.Point(271, 345);
+            this.Hold.Location = new System.Drawing.Point(271, 363);
             this.Hold.Maximum = new decimal(new int[] {
             9999,
             0,
@@ -299,7 +301,7 @@
             // label7
             // 
             this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(12, 433);
+            this.label7.Location = new System.Drawing.Point(12, 451);
             this.label7.Name = "label7";
             this.label7.Size = new System.Drawing.Size(123, 15);
             this.label7.TabIndex = 25;
@@ -307,7 +309,7 @@
             // 
             // Submenu
             // 
-            this.Submenu.Location = new System.Drawing.Point(271, 431);
+            this.Submenu.Location = new System.Drawing.Point(271, 449);
             this.Submenu.Maximum = new decimal(new int[] {
             9999,
             0,
@@ -325,7 +327,7 @@
             // label8
             // 
             this.label8.AutoSize = true;
-            this.label8.Location = new System.Drawing.Point(12, 462);
+            this.label8.Location = new System.Drawing.Point(12, 480);
             this.label8.Name = "label8";
             this.label8.Size = new System.Drawing.Size(138, 15);
             this.label8.TabIndex = 27;
@@ -333,7 +335,7 @@
             // 
             // DateChange
             // 
-            this.DateChange.Location = new System.Drawing.Point(271, 460);
+            this.DateChange.Location = new System.Drawing.Point(271, 478);
             this.DateChange.Maximum = new decimal(new int[] {
             9999,
             0,
@@ -351,7 +353,7 @@
             // label9
             // 
             this.label9.AutoSize = true;
-            this.label9.Location = new System.Drawing.Point(12, 520);
+            this.label9.Location = new System.Drawing.Point(12, 538);
             this.label9.Name = "label9";
             this.label9.Size = new System.Drawing.Size(160, 15);
             this.label9.TabIndex = 29;
@@ -359,7 +361,7 @@
             // 
             // ReturnHome
             // 
-            this.ReturnHome.Location = new System.Drawing.Point(271, 518);
+            this.ReturnHome.Location = new System.Drawing.Point(271, 536);
             this.ReturnHome.Maximum = new decimal(new int[] {
             9999,
             0,
@@ -377,7 +379,7 @@
             // label10
             // 
             this.label10.AutoSize = true;
-            this.label10.Location = new System.Drawing.Point(12, 549);
+            this.label10.Location = new System.Drawing.Point(12, 567);
             this.label10.Name = "label10";
             this.label10.Size = new System.Drawing.Size(119, 15);
             this.label10.TabIndex = 31;
@@ -385,7 +387,7 @@
             // 
             // ReturnGame
             // 
-            this.ReturnGame.Location = new System.Drawing.Point(271, 547);
+            this.ReturnGame.Location = new System.Drawing.Point(271, 565);
             this.ReturnGame.Maximum = new decimal(new int[] {
             9999,
             0,
@@ -403,7 +405,7 @@
             // label11
             // 
             this.label11.AutoSize = true;
-            this.label11.Location = new System.Drawing.Point(12, 491);
+            this.label11.Location = new System.Drawing.Point(12, 509);
             this.label11.Name = "label11";
             this.label11.Size = new System.Drawing.Size(179, 15);
             this.label11.TabIndex = 33;
@@ -411,7 +413,7 @@
             // 
             // DaysToSkip
             // 
-            this.DaysToSkip.Location = new System.Drawing.Point(271, 489);
+            this.DaysToSkip.Location = new System.Drawing.Point(271, 507);
             this.DaysToSkip.Maximum = new decimal(new int[] {
             99,
             0,
@@ -460,7 +462,7 @@
             // label13
             // 
             this.label13.AutoSize = true;
-            this.label13.Location = new System.Drawing.Point(12, 404);
+            this.label13.Location = new System.Drawing.Point(12, 422);
             this.label13.Name = "label13";
             this.label13.Size = new System.Drawing.Size(233, 15);
             this.label13.TabIndex = 39;
@@ -468,7 +470,7 @@
             // 
             // SystemOvershoot
             // 
-            this.SystemOvershoot.Location = new System.Drawing.Point(271, 402);
+            this.SystemOvershoot.Location = new System.Drawing.Point(271, 420);
             this.SystemOvershoot.Maximum = new decimal(new int[] {
             1200,
             0,
@@ -483,11 +485,31 @@
             0,
             0});
             // 
+            // UseOvershoot
+            // 
+            this.UseOvershoot.AutoSize = true;
+            this.UseOvershoot.Location = new System.Drawing.Point(297, 225);
+            this.UseOvershoot.Name = "checkBox1";
+            this.UseOvershoot.Size = new System.Drawing.Size(15, 14);
+            this.UseOvershoot.TabIndex = 41;
+            this.UseOvershoot.UseVisualStyleBackColor = true;
+            // 
+            // label14
+            // 
+            this.label14.AutoSize = true;
+            this.label14.Location = new System.Drawing.Point(12, 224);
+            this.label14.Name = "label14";
+            this.label14.Size = new System.Drawing.Size(221, 15);
+            this.label14.TabIndex = 42;
+            this.label14.Text = "Use overshoot instead of DDOWN inputs";
+            // 
             // ConfigWindow
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(351, 621);
+            this.ClientSize = new System.Drawing.Size(351, 633);
+            this.Controls.Add(this.label14);
+            this.Controls.Add(this.UseOvershoot);
             this.Controls.Add(this.SystemOvershoot);
             this.Controls.Add(this.label13);
             this.Controls.Add(this.EnableDiscordNotifications);
@@ -582,5 +604,7 @@
         private CheckBox EnableDiscordNotifications;
         private Label label13;
         private NumericUpDown SystemOvershoot;
+        private CheckBox UseOvershoot;
+        private Label label14;
     }
 }

--- a/Subforms/ConfigWindow.cs
+++ b/Subforms/ConfigWindow.cs
@@ -18,6 +18,7 @@ namespace RaidCrawler.Subforms
             DiscordWebhook.Enabled = EnableDiscordNotifications.Checked;
 
             UseTouch.Checked = Settings.Default.CfgUseTouch;
+            UseOvershoot.Checked = Settings.Default.CfgUseOvershoot;
             BaseDelay.Value = Settings.Default.CfgBaseDelay;
             OpenHome.Value = Settings.Default.CfgOpenHome;
             NavigateToSettings.Value = Settings.Default.CfgNavigateToSettings;
@@ -52,6 +53,7 @@ namespace RaidCrawler.Subforms
             Settings.Default.CfgDiscordWebhook = DiscordWebhook.Text;
 
             Settings.Default.CfgUseTouch = UseTouch.Checked;
+            Settings.Default.CfgUseOvershoot = UseOvershoot.Checked;
             Settings.Default.CfgBaseDelay = BaseDelay.Value;
             Settings.Default.CfgOpenHome = OpenHome.Value;
             Settings.Default.CfgNavigateToSettings = NavigateToSettings.Value;

--- a/Subforms/ConfigWindow.cs
+++ b/Subforms/ConfigWindow.cs
@@ -24,6 +24,7 @@ namespace RaidCrawler.Subforms
             OpenSettings.Value = Settings.Default.CfgOpenSettings;
             Hold.Value = Settings.Default.CfgHold;
             SystemDDownPresses.Value = Settings.Default.CfgSystemDDownPresses;
+            SystemOvershoot.Value = Settings.Default.CfgSystemOvershoot;
             Submenu.Value = Settings.Default.CfgSubmenu;
             DateChange.Value = Settings.Default.CfgDateChange;
             DaysToSkip.Value = Settings.Default.CfgDaysToSkip;
@@ -57,6 +58,7 @@ namespace RaidCrawler.Subforms
             Settings.Default.CfgOpenSettings = OpenSettings.Value;
             Settings.Default.CfgHold = Hold.Value;
             Settings.Default.CfgSystemDDownPresses = SystemDDownPresses.Value;
+            Settings.Default.CfgSystemOvershoot = SystemOvershoot.Value;
             Settings.Default.CfgSubmenu = Submenu.Value;
             Settings.Default.CfgDateChange = DateChange.Value;
             Settings.Default.CfgDaysToSkip = DaysToSkip.Value;

--- a/Subforms/FilterSettings.Designer.cs
+++ b/Subforms/FilterSettings.Designer.cs
@@ -510,12 +510,14 @@
             // 
             // ActiveFilters
             // 
+            this.ActiveFilters.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
             this.ActiveFilters.FormattingEnabled = true;
             this.ActiveFilters.ItemHeight = 15;
             this.ActiveFilters.Location = new System.Drawing.Point(257, 23);
             this.ActiveFilters.Name = "ActiveFilters";
             this.ActiveFilters.Size = new System.Drawing.Size(185, 259);
             this.ActiveFilters.TabIndex = 20;
+            this.ActiveFilters.DrawItem += new System.Windows.Forms.DrawItemEventHandler(this.ActiveFilters_DrawItem);
             this.ActiveFilters.SelectedIndexChanged += new System.EventHandler(this.ActiveFilters_SelectedIndexChanged);
             // 
             // FilterName

--- a/Subforms/FilterSettings.cs
+++ b/Subforms/FilterSettings.cs
@@ -292,5 +292,19 @@ namespace RaidCrawler.Subforms
                 Rewards.Text = string.Join(",", s);
             }
         }
+
+        private void ActiveFilters_DrawItem(object sender, DrawItemEventArgs e)
+        {
+            e.DrawBackground();
+
+            ListBox lb = (ListBox)sender;
+            Graphics g = e.Graphics;
+            RaidFilter filter = (RaidFilter)lb.Items[e.Index];
+
+            g.FillRectangle(new SolidBrush(((e.State & DrawItemState.Selected) == DrawItemState.Selected) ? ColorTranslator.FromHtml("#000078d7") : Color.White), e.Bounds);
+            g.DrawString(filter.Name, new Font(Name = "Segoe UI", 9), new SolidBrush(filter.Enabled ? e.ForeColor : Color.Gray), new PointF(e.Bounds.X, e.Bounds.Y));
+
+            e.DrawFocusRectangle();
+        }
     }
 }


### PR DESCRIPTION
Allows for quicker scrolling and configurable among different Switches. From tests: 800 for Lite, 950 for OLED. 900-950 for V1.