### PR TITLE
fix shiny filter

### DIFF
--- a/Structures/RaidFilter.cs
+++ b/Structures/RaidFilter.cs
@@ -82,11 +82,11 @@ namespace RaidCrawler.Structures
             };
         }
 
-        public bool IsShinySatisfied(Raid raid)
+        public bool IsShinySatisfied(ITeraRaid? encounter, Raid raid)
         {
             if (Shiny == false)
                 return true;
-            return raid.IsShiny == true;
+            return Raid.CheckIsShiny(raid, encounter) == true;
         }
 
         public bool IsTeraTypeSatisfied(Raid raid)
@@ -188,7 +188,7 @@ namespace RaidCrawler.Structures
 
         public bool FilterSatisfied(ITeraRaid? encounter, Raid raid, int SandwichBoost)
         {
-            return Enabled && IsIVsSatisfied(encounter, raid) && IsShinySatisfied(raid) && IsSpeciesSatisfied(encounter) && IsFormSatisfied(encounter)
+            return Enabled && IsIVsSatisfied(encounter, raid) && IsShinySatisfied(encounter, raid) && IsSpeciesSatisfied(encounter) && IsFormSatisfied(encounter)
                 && IsNatureSatisfied(encounter, raid) && IsStarsSatisfied(encounter) && IsTeraTypeSatisfied(raid)
                 && IsRewardsSatisfied(encounter, raid, SandwichBoost) && IsGenderSatisfied(encounter, raid) && IsBatchFilterSatisfied(encounter, raid);
         }


### PR DESCRIPTION
Hello !

Small fix for shiny filter. Currently, if a shiny locked mon is being filtered as shiny, the filter will stop even if it's not shiny


(It happened to me and even if I know CInderace is currently shiny locked in raid, I have this filter set up because I generate the filter with https://github.com/pifopi/PKHeX/commit/6c03f4917e85ac65bb392f4f83c1fb53839f0f7b)