### PR TITLE
Add match filter count

### DIFF
--- a/MainWindow.Designer.cs
+++ b/MainWindow.Designer.cs
@@ -171,7 +171,7 @@
             this.LabelLoadedRaids.Name = "LabelLoadedRaids";
             this.LabelLoadedRaids.Size = new System.Drawing.Size(50, 15);
             this.LabelLoadedRaids.TabIndex = 12;
-            this.LabelLoadedRaids.Text = "Shiny: 0";
+            this.LabelLoadedRaids.Text = "Shiny: 0 Match: 0";
             // 
             // TeraType
             // 

--- a/MainWindow.cs
+++ b/MainWindow.cs
@@ -1021,9 +1021,12 @@ namespace RaidCrawler
                 if (raid.IsEvent)
                     eventct++;
             }
+            var filterMatchCount = Enumerable.Range(0, Raids.Count).Count(i => RaidFilters.Any(z => z.FilterSatisfied(Encounters[i], Raids[i], RaidBoost.SelectedIndex)));
+            var shinyCount = Enumerable.Range(0, Raids.Count).Count(i => Raid.CheckIsShiny(Raids[i], Encounters[i]));
 
             toolStripStatus.Text = "Completed!";
-            LabelLoadedRaids.Text = $"Shiny: {Enumerable.Range(0, Raids.Count).Where(i => Raid.CheckIsShiny(Raids[i], Encounters[i])).Count()}";
+            LabelLoadedRaids.Text = $"Shiny: {shinyCount} Match: {filterMatchCount}";
+
             if (Raids.Count > 0)
             {
                 ButtonPrevious.Enabled = true;


### PR DESCRIPTION
## Issue:
I sometimes filter by shinyness and other stuff unrelated to it. The Crawler stops at a shiny found that I don't care about, but I would also like to know if other filters were a match, there is no visual indicator for it.

e.g: I am crawling for Shiny || 6iv ditto || 4iv 0atk 0spd ditto. It stops on a shiny I already have, so I don't want to go to it, I need to scroll through every raid to see if there are others (or Shift+Click scroll, which is fastest but doesn't feel like it is doing anything because it doesn't shift the focus raid, since there are no other matches).

## Solution:
Add a text message next to `Shiny: X` saying `Match: 0` to know at a glance how many of the 69 raids match any filter criteria

