### PR TITLE
supercharge Screenshot button when streamer view is up

### DIFF
--- a/MainWindow.cs
+++ b/MainWindow.cs
@@ -1218,8 +1218,13 @@ namespace RaidCrawler
                 MessageBox.Show("Cannot send a screenshot since switch is not connected.");
                 return;
             }
+            Bitmap? screenshot = null;
+            if (Config.StreamerView)
+            {
+                screenshot = teraRaidView.screenshot();
+            }
 
-            NotificationHandler.SendScreenshot(Config, SwitchConnection);
+            NotificationHandler.SendScreenshot(Config, SwitchConnection, screenshot);
         }
 
         private void ConnectionStatusText_TextChanged(object sender, EventArgs e)

--- a/Subforms/TeraRaidView.cs
+++ b/Subforms/TeraRaidView.cs
@@ -1,4 +1,6 @@
-﻿namespace RaidCrawler.Subforms
+﻿using System.Drawing.Imaging;
+
+namespace RaidCrawler.Subforms
 {
     public partial class TeraRaidView : Form
     {
@@ -103,6 +105,18 @@
         private void TeraRaidView_DoubleClick(object sender, EventArgs e)
         {
             this.Close();
+        }
+
+        public Bitmap screenshot()
+        {
+            var bounds = this.Bounds;
+            var bitmap = new Bitmap(bounds.Width, bounds.Height);
+            
+            using (Graphics g = Graphics.FromImage(bitmap))
+            {
+                g.CopyFromScreen(Point.Empty, Point.Empty, bitmap.Size);
+            }
+            return bitmap;
         }
     }
 }


### PR DESCRIPTION
## Feature

Screenshot button is supercharged if streamer view is up.

If streamer view is up, when you click the screenshot button it will now screenshot the area of the streamer view and attach it to the switch screenshot, making it a nice image to post when announcing your raids :)

This will send the new image to your hooks and also add it to the clipboard

Sample:
![image](https://user-images.githubusercontent.com/15164001/214462353-0b2890a3-5f5d-4e56-8a32-d049a8877b8f.png)
