### PR TITLE
Fix: Tera Shards improperly showing type

### DIFF
--- a/MainWindow.cs
+++ b/MainWindow.cs
@@ -1022,7 +1022,7 @@ namespace RaidCrawler
                 {
                     Raids.Add(raid);
                     Encounters.Add(encounter);
-                    RewardsList.Add(Structures.Rewards.GetRewards(encounter, raid.Seed, raid.TeraType, RaidBoost.SelectedIndex));
+                    RewardsList.Add(Structures.Rewards.GetRewards(encounter, raid.Seed, Raid.GetTeraType(encounter, raid), RaidBoost.SelectedIndex));
                 }
                 if (raid.IsEvent)
                     eventct++;
@@ -1188,7 +1188,7 @@ namespace RaidCrawler
             {
                 var raid = Raids[i];
                 var encounter = Encounters[i];
-                RewardsList.Add(Structures.Rewards.GetRewards(encounter, raid.Seed, raid.TeraType, RaidBoost.SelectedIndex));
+                RewardsList.Add(Structures.Rewards.GetRewards(encounter, raid.Seed, Raid.GetTeraType(encounter, raid), RaidBoost.SelectedIndex));
             }
         }
 

--- a/Structures/RaidFilter.cs
+++ b/Structures/RaidFilter.cs
@@ -68,7 +68,7 @@ namespace RaidCrawler.Structures
         {
             if (RewardItems == null || RewardsCount == 0)
                 return true;
-            var rewards = Rewards.GetRewards(enc, raid.Seed, raid.TeraType, SandwichBoost);
+            var rewards = Rewards.GetRewards(enc, raid.Seed, Raid.GetTeraType(enc, raid), SandwichBoost);
             if (rewards == null)
                 return false;
             var count = rewards.Where(z => RewardItems.Contains(z.Item1)).Count();


### PR DESCRIPTION
## Info

I noticed tera shards were off for events and even sometimes normal raids; after a bit of debugging, realized `raid.TeraType` wasn't always correct but `Raid.GetTeraType()` is

### Before fix:
![image](https://user-images.githubusercontent.com/16292606/229038830-1e4bfebe-3005-4b4b-97f0-d8077ffc4313.png)

### After fix:
![image](https://user-images.githubusercontent.com/16292606/229039035-449e75dc-5383-4882-a6f6-e9526cde77e3.png)

