### PR TITLE
Fix button input date skipping when using 20.0.1

### DIFF
--- a/RaidCrawler.Core/Connection/ConnectionWrapper.cs
+++ b/RaidCrawler.Core/Connection/ConnectionWrapper.cs
@@ -318,7 +318,7 @@ public class ConnectionWrapperAsync(SwitchConnectionConfig Config, Action<string
                     .ConfigureAwait(false);
                 UpdateProgressBar(action, steps);
 
-                for (int i = 0; i < 5; i++)
+                for (int i = 0; i < 7; i++)
                 {
                     await Click(DRIGHT, config.NavigateToSettingsDelay + BaseDelay, token)
                         .ConfigureAwait(false);


### PR DESCRIPTION
20.0.1 adds more buttons which breaks button input date skipping. This commit should fix (tested on my console).